### PR TITLE
Missing prerequisites in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ Apillon prebuilt solutions are plug and play applications which can be deployed 
 
 This ready-made solution is designed to help you give out digital collectibles (called NFTs) to attendances on an event.
 
+** Before getting started, ensure you have: **
+
+- Apillon API key and secret for connection.
+- Created NFT collection using Apillon.
+- Access to an email server's details.
+- A specialized Ethereum wallet for admin panel access.
+
 ## Getting started
 
 Solution consists of 2 main parts, Node.js backend APIs and Vue 3 frontend.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Apillon prebuilt solutions are plug and play applications which can be deployed 
 
 This ready-made solution is designed to help you give out digital collectibles (called NFTs) to attendances on an event.
 
-** Before getting started, ensure you have: **
+**Before getting started, ensure you have:**
 
 - Apillon API key and secret for connection.
 - Created NFT collection using Apillon.


### PR DESCRIPTION
### Detailed Issue
When setting up the project following the README, I was able to get the backend and the frontend running. But when trying to login with a wallet, I got stuck on the admin login screen. Clicking on it gave no response.

### Steps to Reproduce
1. Clone the repo.
2. Create .env on `/backend` and `/frontend`.
3. Fill the necessary values and run both backend and frontend.
4. Open the app in browser, connect with an EVM wallet via Metamask.

### Possible Fix
The problem was fixed once I have created a collection NFT via Apillon dashboard and logged in to the dapp using the admin wallet.

So we need to add the following prerequisites (these are basically the same as stated in other simplet repos):

```
- Apillon API key and secret for connection.
- Created NFT collection using Apillon.
- Access to an email server's details.
- A specialized Ethereum wallet for admin panel access.
```

This PR adds them to the root README.
